### PR TITLE
Have batchCDEC return all rows and remove extra fields

### DIFF
--- a/R/cdecHelpers.R
+++ b/R/cdecHelpers.R
@@ -1060,8 +1060,8 @@ batchCDEC <- function(station, sensor, duration, dateStart, dateEnd = NULL,
 
   if (nrow(finalDf) > 0) {
     # Efficiently remove duplicates that may occur at chunk boundaries
-    finalDf <- distinct(finalDf, "stationId", "sensorNumber", "duration",
-                               "dateTime", .keep_all = T)
+    finalDf <- distinct(finalDf, stationId, sensorNumber, duration, dateTime,
+                        .keep_all = T)
   }
 
   return(finalDf)


### PR DESCRIPTION
batchCDEC was only returning the first row, and had superfluous fields. For example, the example on the help page returned this:

  stationId duration sensorNumber sensorType   dateTime    obsDate value dataFlag units "stationId"
1       BDT        E           20       FLOW 2025-05-03 2025-05-03 -1414     <NA>   CFS   stationId
  "sensorNumber" "duration" "dateTime"
1   sensorNumber   duration   dateTime

I adjusted the final call to dplyr::distinct. 