### PR TITLE
Add option to use batchCDEC within popCDEC

### DIFF
--- a/R/cdecHelpers.R
+++ b/R/cdecHelpers.R
@@ -696,7 +696,8 @@ calcNthNearestCDEC <- function(df, n = 1,
 #' water temperature (`temp`), turbidity (`turbidity`), or electroconductivity
 #' (`ec`). Will default to `temp`.
 #' @param waterColumn Where in the water column to look for sensor data, top
-#' (`top`) or bottom (`bottom`)? Will default to `top`
+#' (`top`) or bottom (`bottom`)? Will default to `top`.
+#' @param batch Should batch processing be used?
 #' @param ... Additional parameters to be passed onto `calcNearestCDEC()`.
 #'
 #' @return A data frame with water quality of interest from the closest CDEC
@@ -714,6 +715,7 @@ popCDEC <- function(df,
                     cdecClosest = NULL,
                     variable = c("temp", "turbidity", "ec"),
                     waterColumn = c("top", "bottom"),
+                    batch=FALSE,
                     ...) {
 
   # --- Validation and preprocessing ---
@@ -763,13 +765,23 @@ popCDEC <- function(df,
 
     dateRange <- range(as.Date(durationSensorGroup$time))
 
-    cdecData <- pullCDEC(
-      station = unique(durationSensorGroup$cdecStation),
-      sensor = unique(durationSensorGroup$sensorNumber),
-      duration = as.character(unique(durationSensorGroup$duration)),
-      dateStart = dateRange[1] - 1, # Add a 1-day buffers
-      dateEnd = dateRange[2] + 1
-    )
+    if(batch) {
+      cdecData <- batchCDEC(
+        station = unique(durationSensorGroup$cdecStation),
+        sensor = unique(durationSensorGroup$sensorNumber),
+        duration = as.character(unique(durationSensorGroup$duration)),
+        dateStart = dateRange[1] - 1, # Add a 1-day buffers
+        dateEnd = dateRange[2] + 1
+      )
+    } else {
+      cdecData <- pullCDEC(
+        station = unique(durationSensorGroup$cdecStation),
+        sensor = unique(durationSensorGroup$sensorNumber),
+        duration = as.character(unique(durationSensorGroup$duration)),
+        dateStart = dateRange[1] - 1, # Add a 1-day buffers
+        dateEnd = dateRange[2] + 1
+      )
+    }
 
     if (is.null(cdecData) || nrow(cdecData) == 0) return(NULL)
 

--- a/man/popCDEC.Rd
+++ b/man/popCDEC.Rd
@@ -9,6 +9,7 @@ popCDEC(
   cdecClosest = NULL,
   variable = c("temp", "turbidity", "ec"),
   waterColumn = c("top", "bottom"),
+  batch = FALSE,
   ...
 )
 }
@@ -28,7 +29,9 @@ water temperature (\code{temp}), turbidity (\code{turbidity}), or electroconduct
 (\code{ec}). Will default to \code{temp}.}
 
 \item{waterColumn}{Where in the water column to look for sensor data, top
-(\code{top}) or bottom (\code{bottom})? Will default to \code{top}}
+(\code{top}) or bottom (\code{bottom})? Will default to \code{top}.}
+
+\item{batch}{Should batch processing be used?}
 
 \item{...}{Additional parameters to be passed onto \code{calcNearestCDEC()}.}
 }


### PR DESCRIPTION
If too many CDEC records are requested at once, popCDEC throws an error and suggests using batchCDEC instead of pullCDEC. Might be useful to have an option to do this within popCDEC directly.  (I know I still have failed checks, but I think this suggested change is minor enough that I'm not too worried about it.)